### PR TITLE
🐛 make sure to attach getters and setters during class combination

### DIFF
--- a/index.js
+++ b/index.js
@@ -39,7 +39,15 @@ function multiclass(...classes) {
 						}
 					} else {
 						// otherwise, we'll just attach it to our Class frame
-						Class.prototype[property] = baseClass.prototype[property];
+						let propertyDescriptor = Reflect.getOwnPropertyDescriptor(
+							baseClass.prototype,
+							property,
+						);
+						Reflect.defineProperty(
+							Class.prototype,
+							property,
+							propertyDescriptor,
+						);
 					}
 				}
 			}

--- a/test.js
+++ b/test.js
@@ -4,11 +4,15 @@ const multiclass = require("./index");
 
 class HasAge {
 	constructor({age}) {
-		this.age = age;
+		this._age = age;
 	}
 
-	getAge() {
-		return this.age;
+	set age(age) {
+		this._age = age;
+	}
+
+	get age() {
+		return this._age;
 	}
 }
 
@@ -62,9 +66,12 @@ test(
 	"Test multi-class inheritance",
 	() => {
 		assert.strictEqual(leeloo.getName(), "Leeloo");
-		assert.strictEqual(leeloo.getAge(), 22);
+		assert.strictEqual(leeloo.age, 22);
 		assert.strictEqual(leeloo.getNameAndAge(), "Leeloo is 22 years old.");
 		assert.strictEqual(leeloo.element, "fifth");
+		// getters and setters
+		leeloo.age = 23;
+		assert.strictEqual(leeloo.age, 23);
 		// static inheritance
 		assert.ok(FifthElement.isElement("air"));
 		assert.throws(() => leeloo.isElement("air"));


### PR DESCRIPTION
I was originally referencing the properties on the base class using the basic
bracket reference baseClass.prototype[property], but getters and setters can't
 be retrieved this way. Instead, I've replaced that with Reflect.getOwnPropertyDescriptor(),
which grabs all elements of the property. I can then re-attach it with Reflect.defineProperty().